### PR TITLE
WIP: Add base command class

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,7 @@
 {
   "extends": "oclif",
   "rules": {
+    "brace-style": ["error", "1tbs", { "allowSingleLine": true }],
     "comma-dangle": ["error",  "only-multiline"],
     "consistent-return": "off",  "arrow-parens": ["error",  "as-needed"],
     "curly": ["error",  "all"],
@@ -17,6 +18,7 @@
     "no-use-before-define": ["error", { "variables": false }],
     "no-warning-comments": [1],
     "object-curly-spacing": [2,  "always"],
-    "semi": ["error",  "always", { "omitLastInOneLineBlock": true }]
+    "semi": ["error",  "always", { "omitLastInOneLineBlock": true }],
+    "valid-jsdoc": "off"
   }
 }

--- a/package.json
+++ b/package.json
@@ -30,10 +30,11 @@
     "lint-staged": "^8.1.5",
     "mocha": "^5",
     "nyc": "^13",
-    "prettier-eslint-cli": "^4.7.1"
+    "prettier-eslint-cli": "^4.7.1",
+    "sinon": "^7.3.1"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "files": [
     "/bin",

--- a/src/base.js
+++ b/src/base.js
@@ -1,0 +1,93 @@
+// src/base.ts
+const { Command, flags: flagType } = require('@oclif/command');
+
+class BaseCommand extends Command {
+  constructor(...props) {
+    super(...props);
+    this.printLog = super.log;
+    this.printWarning = super.warn;
+    this.printError = super.error;
+  }
+
+  parse() {
+    return super.parse(BaseCommand);
+  }
+
+  log(msg, { verbose } = {}, logger = this.printLog) {
+    const { flags } = this.parse(BaseCommand);
+
+    // Silent prevents any log
+    if (flags.silent) {
+      return;
+    }
+
+    // Log is marked verbose, but the verbose flag is not present
+    if (!flags.verbose && verbose) {
+      return;
+    }
+
+    logger(msg);
+  }
+
+  warn(msg, { verbose } = {}, logger = this.printWarning) {
+    const { flags } = this.parse(BaseCommand);
+
+    // Log is marked verbose, but the verbose flag is not present
+    if (!flags.verbose && verbose) {
+      return;
+    }
+
+    logger(msg);
+  }
+
+  error(msg, options = {}, logger = this.printError) {
+    logger(msg, options);
+  }
+}
+
+/**
+ * Default arguments
+ */
+BaseCommand.args = [];
+
+/**
+ * Default flags
+ */
+BaseCommand.flags = {
+  silent: flagType.boolean({
+    description: 'skip rayctl logs, other logs will be printed'
+    // exclusive: ['verbose'],
+  }),
+  verbose: flagType.boolean({
+    description: 'output verbose messages on internal operations'
+    // exclusive: ['silent'],
+  })
+};
+
+/**
+ * Set arguments for the command extending `BaseCommand`
+ *
+ * The arguments will extend the default arguments of `BaseCommand`.
+ * @param args List of argumets accepted by a given command.
+ */
+BaseCommand.setArgs = args => {
+  BaseCommand.args = [...BaseCommand.args, ...args];
+};
+
+/**
+ * Set flags for the command extending `BaseCommand`
+ *
+ * The arguments will extend the default flags of `BaseCommand`.
+ * @param flags Dictionary of flags accepted by a given command.
+ */
+BaseCommand.setFlags = (flags = {}) => {
+  BaseCommand.flags = {
+    ...BaseCommand.flags,
+    ...flags
+  };
+};
+
+module.exports = {
+  Command: BaseCommand,
+  flags: flagType
+};

--- a/src/base.js
+++ b/src/base.js
@@ -2,6 +2,17 @@
 const { Command, flags: flagType } = require('@oclif/command');
 
 class BaseCommand extends Command {
+  /**
+   * Constructor
+   *
+   * The constructor assigns three public methods
+   *   - printLog: prints to the stdout.
+   *   - printWarn: prints to the stderr.
+   *   - printError: prints to the stderr and exits with 1.
+   * These methods are used respectively in `this.log`, `this.warn` and
+   * `this.error`. They are the default functions used to log.
+   * @param props Props to be forwarded to parent constructor.
+   */
   constructor(...props) {
     super(...props);
     this.printLog = super.log;
@@ -9,15 +20,46 @@ class BaseCommand extends Command {
     this.printError = super.error;
   }
 
+  /**
+   * Parse command's arguments and flags
+   *
+   * This method is used to retrieve arguments and flags passed to a command
+   *   const { args, flags } = this.parse();
+   * Usually it is used in the `run` method of a command.
+   * @returns The parsed command's arguments and flags (as well as other data).
+   */
   parse() {
     return super.parse(BaseCommand);
   }
 
+  /**
+   * Log messages
+   *
+   * It logs messages (by default to stdout, but it can be overridden), with the
+   * option to define verbose logs (logs which are only visible when a command
+   * is invoked with the `--verbose` flag); logs can be disabled completely by
+   * using the `--silence` flag. The user can also specify which function to use
+   * to log.
+   *
+   * Example usage
+   *   this.log('This is a message');
+   *   this.log('This is a verbose message', { verbose: true })'
+   *   this.log('This message uses a custom logger', {}, console.log)'
+   * @param msg Message to be logged.
+   * @param options (default = {})
+   *   - verbose: If marked verbose, a log is printed only if the command is
+   *     invoked with the `--verbose` flag
+   *       $ rayctl command --verbose
+   * @param logger (default = this.printLog) Function used to actually log.
+   * The `logger` has the following signature
+   *   logger(msg: string)
+   *     - msg: The message to be logged.
+   */
   log(msg, { verbose } = {}, logger = this.printLog) {
     const { flags } = this.parse(BaseCommand);
 
     // Silent prevents any log
-    if (flags.silent) {
+    if (flags.silent || flags.quiet) {
       return;
     }
 
@@ -29,6 +71,28 @@ class BaseCommand extends Command {
     logger(msg);
   }
 
+  /**
+   * Log warnings
+   *
+   * It logs warnings (by default to stderr, but it can be overridden), with the
+   * option to define verbose logs (warnings which are only visible when a
+   * command is invoked with the `--verbose` flag). The user can also specify
+   * which function to use to log.
+   *
+   * Example usage
+   *   this.warn('This is a warning');
+   *   this.warn('This is a verbose warning', { verbose: true })'
+   *   this.warn('This warning uses a custom logger', {}, console.warn)'
+   * @param msg Warning message to be logged.
+   * @param options (default = {})
+   *   - verbose: If marked verbose, a warning is printed only if the command is
+   *   invoked with the `--verbose` flag
+   *       $ rayctl command --verbose
+   * @param logger (default = this.printWarning) Function used to actually log.
+   * The `logger` has the following signature
+   *   logger(msg: string)
+   *     - msg: The warning message to be logged.
+   */
   warn(msg, { verbose } = {}, logger = this.printWarning) {
     const { flags } = this.parse(BaseCommand);
 
@@ -40,27 +104,55 @@ class BaseCommand extends Command {
     logger(msg);
   }
 
+  /**
+   * Log errors
+   *
+   * It logs errors (by default to stderr, followed by an exit 1). The user can
+   * also specify which function to use to log.
+   *
+   * Example usage
+   *   this.error('This is an error');
+   *   this.error('This is error uses a custom logger', {}, console.error)'
+   * @param msg Error message to be logged.
+   * @param options (default = {})
+   *   - verbose: If marked verbose, an error is printed only if the command is
+   *   invoked with the `--verbose` flag
+   *       $ rayctl command --verbose
+   * @param logger (default = this.printError) Function used to actually log.
+   * The `logger` has the following signature
+   *   logger(msg: string, options: { code: string, exit: number })
+   *     - msg: The error message to be logged.
+   *     - options:
+   *         - code: Code for the error.
+   *         - exit: Exit number.
+   *   When passing a custom logger, keep in mind that it should exit after
+   *   logging the error.
+   */
   error(msg, options = {}, logger = this.printError) {
     logger(msg, options);
   }
 }
 
 /**
- * Default arguments
+ * Default arguments, passed to all commands inheriting from BaseCommand
  */
 BaseCommand.args = [];
 
 /**
- * Default flags
+ * Default flags, passed to all commands inheriting from BaseCommand
  */
 BaseCommand.flags = {
+  quiet: flagType.boolean({
+    description: 'skip rayctl logs, other logs will be printed',
+    exclusive: ['verbose']
+  }),
   silent: flagType.boolean({
-    description: 'skip rayctl logs, other logs will be printed'
-    // exclusive: ['verbose'],
+    description: 'skip rayctl logs, other logs will be printed',
+    exclusive: ['verbose']
   }),
   verbose: flagType.boolean({
-    description: 'output verbose messages on internal operations'
-    // exclusive: ['silent'],
+    description: 'output verbose messages on internal operations',
+    exclusive: ['silent', 'quiet']
   })
 };
 

--- a/test/base.test.js
+++ b/test/base.test.js
@@ -1,0 +1,270 @@
+const { expect, test } = require('@oclif/test');
+const sinon = require('sinon');
+const { Command } = require('../src/base');
+
+/* eslint-disable no-console */
+class TestLogCommand extends Command {
+  async run() {
+    this.log('log');
+  }
+}
+
+class TestLogVerboseCommand extends Command {
+  async run() {
+    this.log('log verbose', { verbose: true });
+  }
+}
+
+class TestLogCustomCommand extends Command {
+  async run() {
+    this.log('log custom', {}, console.log);
+  }
+}
+
+class TestWarnCommand extends Command {
+  async run() {
+    this.warn('warn');
+  }
+}
+
+class TestWarnVerboseCommand extends Command {
+  async run() {
+    this.warn('warn verbose', { verbose: true });
+  }
+}
+
+class TestWarnCustomCommand extends Command {
+  async run() {
+    this.warn('warn custom', {}, console.warn);
+  }
+}
+
+class TestErrorCommand extends Command {
+  async run() {
+    this.error('error', {});
+  }
+}
+
+class TestErrorCustomCommand extends Command {
+  async run() {
+    this.error('error custom', {}, console.error);
+  }
+}
+
+describe('command', () => {
+  /**
+   * Logs
+   */
+  test.it('logs normally without flags', async () => {
+    const testCommand = new TestLogCommand([], {});
+    sinon.stub(testCommand, 'printLog');
+
+    await testCommand.run();
+    expect(testCommand.printLog.calledWith('log')).to.equal(true);
+
+    testCommand.printLog.restore();
+  });
+
+  test.it('logs normally with `--verbose` flag', async () => {
+    const testCommand = new TestLogCommand(['--verbose'], {});
+    sinon.stub(testCommand, 'printLog');
+
+    await testCommand.run();
+    expect(testCommand.printLog.calledWith('log')).to.equal(true);
+
+    testCommand.printLog.restore();
+  });
+
+  test.it("doesn't log normally with `--silent` flag", async () => {
+    const testCommand = new TestLogCommand(['--silent'], {});
+    sinon.stub(testCommand, 'printLog');
+
+    await testCommand.run();
+    expect(testCommand.printLog.calledWith('log')).to.equal(false);
+
+    testCommand.printLog.restore();
+  });
+
+  test.it('throws an error with both `--silent` and `--verbose` flags', async () => {
+    const testCommand = new TestLogCommand(['--silent', '--verbose'], {});
+    const errorMessage = '--verbose= cannot also be provided when using --silent=';
+    testCommand
+      .run()
+      .then(() => {
+        throw new Error(errorMessage);
+      })
+      .catch(error => expect(error.message).to.equal(errorMessage));
+  });
+
+  /**
+   * Verbose logs
+   */
+  test.it("doesn't log verbose without flags", async () => {
+    const testCommand = new TestLogVerboseCommand([], {});
+    sinon.stub(testCommand, 'printLog');
+
+    await testCommand.run();
+    expect(testCommand.printLog.calledWith('log verbose')).to.equal(false);
+
+    testCommand.printLog.restore();
+  });
+
+  test.it('logs verbose with `--verbose` flag', async () => {
+    const testCommand = new TestLogVerboseCommand(['--verbose'], {});
+    sinon.stub(testCommand, 'printLog');
+
+    await testCommand.run();
+    expect(testCommand.printLog.calledWith('log verbose')).to.equal(true);
+
+    testCommand.printLog.restore();
+  });
+
+  test.it("doesn't log verbose with `--silent` flag", async () => {
+    const testCommand = new TestLogVerboseCommand(['--silent'], {});
+    sinon.stub(testCommand, 'printLog');
+
+    await testCommand.run();
+    expect(testCommand.printLog.calledWith('log verbose')).to.equal(false);
+
+    testCommand.printLog.restore();
+  });
+
+  /**
+   * Custom log logger
+   */
+  test.it('logs normally with custom logger', async () => {
+    const testCommand = new TestLogCustomCommand([], {});
+    sinon.stub(console, 'log');
+
+    await testCommand.run();
+    expect(console.log.calledWith('log custom')).to.equal(true);
+
+    console.log.restore();
+  });
+
+  /**
+   * Warnings
+   */
+  test.it('warns normally without flags', async () => {
+    const testCommand = new TestWarnCommand([], {});
+    sinon.stub(testCommand, 'printWarning');
+
+    await testCommand.run();
+    expect(testCommand.printWarning.calledWith('warn')).to.equal(true);
+
+    testCommand.printWarning.restore();
+  });
+
+  test.it('warns normally with `--verbose` flag', async () => {
+    const testCommand = new TestWarnCommand(['--verbose'], {});
+    sinon.stub(testCommand, 'printWarning');
+
+    await testCommand.run();
+    expect(testCommand.printWarning.calledWith('warn')).to.equal(true);
+
+    testCommand.printWarning.restore();
+  });
+
+  test.it('warns normally with `--silent` flag', async () => {
+    const testCommand = new TestWarnCommand(['--silent'], {});
+    sinon.stub(testCommand, 'printWarning');
+
+    await testCommand.run();
+    expect(testCommand.printWarning.calledWith('warn')).to.equal(true);
+
+    testCommand.printWarning.restore();
+  });
+
+  /**
+   * Verbose logs
+   */
+  test.it("doesn't warn verbose without flags", async () => {
+    const testCommand = new TestWarnVerboseCommand([], {});
+    sinon.stub(testCommand, 'printWarning');
+
+    await testCommand.run();
+    expect(testCommand.printWarning.calledWith('warn verbose')).to.equal(false);
+
+    testCommand.printWarning.restore();
+  });
+
+  test.it('warns verbose with `--verbose` flag', async () => {
+    const testCommand = new TestWarnVerboseCommand(['--verbose'], {});
+    sinon.stub(testCommand, 'printWarning');
+
+    await testCommand.run();
+    expect(testCommand.printWarning.calledWith('warn verbose')).to.equal(true);
+
+    testCommand.printWarning.restore();
+  });
+
+  test.it("doesn't warn verbose with `--silent` flag", async () => {
+    const testCommand = new TestWarnVerboseCommand(['--silent'], {});
+    sinon.stub(testCommand, 'printWarning');
+
+    await testCommand.run();
+    expect(testCommand.printWarning.calledWith('warn verbose')).to.equal(false);
+
+    testCommand.printWarning.restore();
+  });
+
+  /**
+   * Custom warning logger
+   */
+  test.it('logs normally with custom logger', async () => {
+    const testCommand = new TestWarnCustomCommand([], {});
+    sinon.stub(console, 'warn');
+
+    await testCommand.run();
+    expect(console.warn.calledWith('warn custom')).to.equal(true);
+
+    console.warn.restore();
+  });
+
+  /**
+   * Errors
+   */
+  test.it('prints error without flags', async () => {
+    const testCommand = new TestErrorCommand([], {});
+    sinon.stub(testCommand, 'printError');
+
+    await testCommand.run();
+    expect(testCommand.printError.calledWith('error')).to.equal(true);
+
+    testCommand.printError.restore();
+  });
+
+  test.it('prints error with `--verbose` flag', async () => {
+    const testCommand = new TestErrorCommand(['--verbose'], {});
+    sinon.stub(testCommand, 'printError');
+
+    await testCommand.run();
+    expect(testCommand.printError.calledWith('error')).to.equal(true);
+
+    testCommand.printError.restore();
+  });
+
+  test.it('prints error with `--silent` flag', async () => {
+    const testCommand = new TestErrorCommand(['--verbose'], {});
+    sinon.stub(testCommand, 'printError');
+
+    await testCommand.run();
+    expect(testCommand.printError.calledWith('error')).to.equal(true);
+
+    testCommand.printError.restore();
+  });
+
+  /**
+   * Custom error logger
+   */
+  test.it('prints error with custom logger', async () => {
+    const testCommand = new TestErrorCustomCommand([], {});
+    sinon.stub(console, 'error');
+
+    await testCommand.run();
+    expect(console.error.calledWith('error custom')).to.equal(true);
+
+    console.error.restore();
+  });
+});
+/* eslint-enable no-console */

--- a/test/base.test.js
+++ b/test/base.test.js
@@ -2,7 +2,27 @@ const { expect, test } = require('@oclif/test');
 const sinon = require('sinon');
 const { Command } = require('../src/base');
 
-/* eslint-disable no-console */
+/* eslint-disable no-console,no-process-exit,unicorn/no-process-exit */
+/**
+ * Custom loggers
+ */
+const logger = {
+  info: msg => {
+    console.log(msg);
+  },
+  warn: msg => {
+    console.warn(msg);
+  },
+  error: (msg, { exit } = {}) => {
+    console.error(msg);
+    process.exit(exit || 1);
+  }
+};
+/* eslint-enable no-console,no-process-exit,unicorn/no-process-exit */
+
+/**
+ * Custom Command classes for tests
+ */
 class TestLogCommand extends Command {
   async run() {
     this.log('log');
@@ -17,7 +37,7 @@ class TestLogVerboseCommand extends Command {
 
 class TestLogCustomCommand extends Command {
   async run() {
-    this.log('log custom', {}, console.log);
+    this.log('log custom', {}, logger.info);
   }
 }
 
@@ -35,7 +55,7 @@ class TestWarnVerboseCommand extends Command {
 
 class TestWarnCustomCommand extends Command {
   async run() {
-    this.warn('warn custom', {}, console.warn);
+    this.warn('warn custom', {}, logger.warn);
   }
 }
 
@@ -47,10 +67,13 @@ class TestErrorCommand extends Command {
 
 class TestErrorCustomCommand extends Command {
   async run() {
-    this.error('error custom', {}, console.error);
+    this.error('error custom', {}, logger.error);
   }
 }
 
+/**
+ * Tests
+ */
 describe('command', () => {
   /**
    * Logs
@@ -134,12 +157,12 @@ describe('command', () => {
    */
   test.it('logs normally with custom logger', async () => {
     const testCommand = new TestLogCustomCommand([], {});
-    sinon.stub(console, 'log');
+    sinon.stub(logger, 'info');
 
     await testCommand.run();
-    expect(console.log.calledWith('log custom')).to.equal(true);
+    expect(logger.info.calledWith('log custom')).to.equal(true);
 
-    console.log.restore();
+    logger.info.restore();
   });
 
   /**
@@ -213,12 +236,12 @@ describe('command', () => {
    */
   test.it('logs normally with custom logger', async () => {
     const testCommand = new TestWarnCustomCommand([], {});
-    sinon.stub(console, 'warn');
+    sinon.stub(logger, 'warn');
 
     await testCommand.run();
-    expect(console.warn.calledWith('warn custom')).to.equal(true);
+    expect(logger.warn.calledWith('warn custom')).to.equal(true);
 
-    console.warn.restore();
+    logger.warn.restore();
   });
 
   /**
@@ -259,12 +282,11 @@ describe('command', () => {
    */
   test.it('prints error with custom logger', async () => {
     const testCommand = new TestErrorCustomCommand([], {});
-    sinon.stub(console, 'error');
+    sinon.stub(logger, 'error');
 
     await testCommand.run();
-    expect(console.error.calledWith('error custom')).to.equal(true);
+    expect(logger.error.calledWith('error custom')).to.equal(true);
 
-    console.error.restore();
+    logger.error.restore();
   });
 });
-/* eslint-enable no-console */

--- a/yarn.lock
+++ b/yarn.lock
@@ -204,6 +204,35 @@
   dependencies:
     any-observable "^0.3.0"
 
+"@sinonjs/commons@^1", "@sinonjs/commons@^1.0.2", "@sinonjs/commons@^1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.4.0.tgz#7b3ec2d96af481d7a0321252e7b1c94724ec5a78"
+  integrity sha512-9jHK3YF/8HtJ9wCAbG+j8cD0i0+ATS9A7gXFqS36TblLPNy6rEEc+SB0imo91eCboGaBYGV/MT1/br/J+EE7Tw==
+  dependencies:
+    type-detect "4.0.8"
+
+"@sinonjs/formatio@^3.1.0", "@sinonjs/formatio@^3.2.1":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@sinonjs/formatio/-/formatio-3.2.1.tgz#52310f2f9bcbc67bdac18c94ad4901b95fde267e"
+  integrity sha512-tsHvOB24rvyvV2+zKMmPkZ7dXX6LSLKZ7aOtXY6Edklp0uRcgGpOsQTTGTcWViFyx4uhWc6GV8QdnALbIbIdeQ==
+  dependencies:
+    "@sinonjs/commons" "^1"
+    "@sinonjs/samsam" "^3.1.0"
+
+"@sinonjs/samsam@^3.1.0", "@sinonjs/samsam@^3.3.1":
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/@sinonjs/samsam/-/samsam-3.3.1.tgz#e88c53fbd9d91ad9f0f2b0140c16c7c107fe0d07"
+  integrity sha512-wRSfmyd81swH0hA1bxJZJ57xr22kC07a1N4zuIL47yTS04bDk6AoCkczcqHEjcRPmJ+FruGJ9WBQiJwMtIElFw==
+  dependencies:
+    "@sinonjs/commons" "^1.0.2"
+    array-from "^2.1.1"
+    lodash "^4.17.11"
+
+"@sinonjs/text-encoding@^0.7.1":
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz#8da5c6530915653f3a1f38fd5f101d8c3f8079c5"
+  integrity sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==
+
 "@types/chai@*":
   version "4.1.7"
   resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.1.7.tgz#1b8e33b61a8c09cbe1f85133071baa0dbf9fa71a"
@@ -368,6 +397,11 @@ arr-union@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/arr-union/-/arr-union-3.1.0.tgz#e39b09aea9def866a8f206e288af63919bae39c4"
   integrity sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=
+
+array-from@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/array-from/-/array-from-2.1.1.tgz#cfe9d8c26628b9dc5aecc62a9f5d8f1f352c1195"
+  integrity sha1-z+nYwmYoudxa7MYqn12PHzUsEZU=
 
 array-union@^1.0.1:
   version "1.0.2"
@@ -1016,7 +1050,7 @@ detect-indent@^5.0.0:
   resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-5.0.0.tgz#3871cc0a6a002e8c3e5b3cf7f336264675f06b9d"
   integrity sha1-OHHMCmoALow+Wzz38zYmRnXwa50=
 
-diff@3.5.0:
+diff@3.5.0, diff@^3.5.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
   integrity sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==
@@ -2177,6 +2211,11 @@ is-wsl@^1.1.0:
   resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-1.1.0.tgz#1f16e4aa22b04d1336b66188a66af3c600c3a66d"
   integrity sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=
 
+isarray@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
+  integrity sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=
+
 isarray@1.0.0, isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
@@ -2300,6 +2339,11 @@ jsonfile@^4.0.0:
   integrity sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=
   optionalDependencies:
     graceful-fs "^4.1.6"
+
+just-extend@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/just-extend/-/just-extend-4.0.2.tgz#f3f47f7dfca0f989c55410a7ebc8854b07108afc"
+  integrity sha512-FrLwOgm+iXrPV+5zDU6Jqu4gCRXbWEQg2O3SKONsWE4w7AXFRkryS53bpWdaL9cNol+AmR3AEYz6kn+o0fCPnw==
 
 kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0:
   version "3.2.2"
@@ -2570,6 +2614,16 @@ loglevel@^1.4.1:
   resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.6.1.tgz#e0fc95133b6ef276cdc8887cdaf24aa6f156f8fa"
   integrity sha1-4PyVEztu8nbNyIh82vJKpvFW+Po=
 
+lolex@^2.3.2:
+  version "2.7.5"
+  resolved "https://registry.yarnpkg.com/lolex/-/lolex-2.7.5.tgz#113001d56bfc7e02d56e36291cc5c413d1aa0733"
+  integrity sha512-l9x0+1offnKKIzYVjyXU2SiwhXDLekRzKyhnbyldPHvC7BvLPVpdNUNR2KeMAiCN2D/kLNttZgQD5WjSxuBx3Q==
+
+lolex@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/lolex/-/lolex-3.1.0.tgz#1a7feb2fefd75b3e3a7f79f0e110d9476e294434"
+  integrity sha512-zFo5MgCJ0rZ7gQg69S4pqBsLURbFw11X68C18OcJjJQbqaXm2NoTrGl1IMM3TIz0/BnN1tIs2tzmmqvCsOMMjw==
+
 lru-cache@^4.0.1:
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.5.tgz#8bbe50ea85bed59bc9e33dcab8235ee9bcf443cd"
@@ -2814,6 +2868,17 @@ nice-try@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
+
+nise@^1.4.10:
+  version "1.4.10"
+  resolved "https://registry.yarnpkg.com/nise/-/nise-1.4.10.tgz#ae46a09a26436fae91a38a60919356ae6db143b6"
+  integrity sha512-sa0RRbj53dovjc7wombHmVli9ZihXbXCQ2uH3TNm03DyvOSIQbxg+pbqDKrk2oxMK1rtLGVlKxcB9rrc6X5YjA==
+  dependencies:
+    "@sinonjs/formatio" "^3.1.0"
+    "@sinonjs/text-encoding" "^0.7.1"
+    just-extend "^4.0.2"
+    lolex "^2.3.2"
+    path-to-regexp "^1.7.0"
 
 nopt@~3.0.6:
   version "3.0.6"
@@ -3110,6 +3175,13 @@ path-parse@^1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.6.tgz#d62dbb5679405d72c4737ec58600e9ddcf06d24c"
   integrity sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==
+
+path-to-regexp@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.7.0.tgz#59fde0f435badacba103a84e9d3bc64e96b9937d"
+  integrity sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=
+  dependencies:
+    isarray "0.0.1"
 
 path-type@^3.0.0:
   version "3.0.0"
@@ -3597,6 +3669,19 @@ simple-git@^1.85.0:
   dependencies:
     debug "^4.0.1"
 
+sinon@^7.3.1:
+  version "7.3.1"
+  resolved "https://registry.yarnpkg.com/sinon/-/sinon-7.3.1.tgz#e8276522104e6c08d1cb52a907270b0e316655c4"
+  integrity sha512-eQKMaeWovtOtYe2xThEvaHmmxf870Di+bim10c3ZPrL5bZhLGtu8cz+rOBTFz0CwBV4Q/7dYwZiqZbGVLZ+vjQ==
+  dependencies:
+    "@sinonjs/commons" "^1.4.0"
+    "@sinonjs/formatio" "^3.2.1"
+    "@sinonjs/samsam" "^3.3.1"
+    diff "^3.5.0"
+    lolex "^3.1.0"
+    nise "^1.4.10"
+    supports-color "^5.5.0"
+
 slash@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-1.0.0.tgz#c41f2f6c39fc16d1cd17ad4b5d896114ae470d55"
@@ -4042,7 +4127,7 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
-type-detect@^4.0.0, type-detect@^4.0.5:
+type-detect@4.0.8, type-detect@^4.0.0, type-detect@^4.0.5:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
   integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==


### PR DESCRIPTION
## Description

Add a `BaseCommand` class, from which all commands should inherit from.

This class a few functionalities to the oclif `Command` class:
- custom logs, warnings and errors;
-  `--verbose` and `--silent` flags to all commands, used to suppress logs or print additional information;
- easier access to args/flags via `this.args` and `this.flags`, without having to invoke `this.parse(this.constructor)` explicitly.

This implementation requires to implement commands slightly differently with respect to the oclif implementation. For more detailed instructions, read the documentation in `docs/contributing/commands.md`.


## Type of change

- New feature (non-breaking change which adds functionality)


## How has this been tested?

- [x] Print logs with/without `--verbose` and `--silent` flags.
- [x] Print warnings with/without `--verbose` and `--silent` flags.
- [x] Print errors with/without `--verbose` and `--silent` flags.
- [x] Print logs with both `--verbose` and `--silent` flags.
- [x] Set command arguments.
- [x] Set command flags.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have updated the changelog
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
